### PR TITLE
gracefuly handle missing text file

### DIFF
--- a/wut.py
+++ b/wut.py
@@ -68,12 +68,17 @@ class Markov(object):
 here = os.path.abspath(os.path.dirname(__file__))
 text_path = os.path.join(here, 'text')
 
-with open(text_path) as t:
-    m = Markov(t)
+try:
+    with open(text_path) as t:
+        m = Markov(t)
+except IOError:
+    logger.error('could not load text at %s. disabling' % text_path)
+    m = None
 
 
 def is_getting_asked(message, botnick=None):
-
+    if not m:
+        return False
     botnick = botnick or settings.NICK
     message = message.strip()
     if message.startswith(botnick) and message.endswith('?'):


### PR DESCRIPTION
Prior to this change, the `IOError` on a missing text file would cause Helga to fail to load the entrypoint on start. Additionally Helga would log this entrypoint error on every single IRC action.

Gracefully handle the missing text file so we only see a single error in the helga log at startup.